### PR TITLE
Removed bootstrap-servers from xml

### DIFF
--- a/src/main/java/com/gznznzjsn/taskservice/web/kafka/RequirementProducerConfig.java
+++ b/src/main/java/com/gznznzjsn/taskservice/web/kafka/RequirementProducerConfig.java
@@ -33,8 +33,6 @@ public class RequirementProducerConfig {
     public SenderOptions<String, Requirement> senderOptions() {
         XMLParser parser = new XMLParser(requirementProducerSettings);
         Map<String, Object> properties = new HashMap<>();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                parser.parse("bootstrapServers"));
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 parser.parse("keySerializerClass"));
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,

--- a/src/main/java/com/gznznzjsn/taskservice/web/kafka/TaskConsumerConfig.java
+++ b/src/main/java/com/gznznzjsn/taskservice/web/kafka/TaskConsumerConfig.java
@@ -24,8 +24,6 @@ public class TaskConsumerConfig {
     public ReceiverOptions<String, String> receiverOptions() {
         XMLParser parser = new XMLParser(taskConsumerSettings);
         Map<String, Object> properties = new HashMap<>();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                parser.parse("bootstrapServers"));
         properties.put(ConsumerConfig.GROUP_ID_CONFIG,
                 parser.parse("groupId"));
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,

--- a/src/main/java/com/gznznzjsn/taskservice/web/kafka/TaskConsumerConfig.java
+++ b/src/main/java/com/gznznzjsn/taskservice/web/kafka/TaskConsumerConfig.java
@@ -5,6 +5,7 @@ import com.gznznzjsn.taskservice.web.kafka.parser.XMLParser;
 import com.jcabi.xml.XML;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import reactor.kafka.receiver.KafkaReceiver;
@@ -18,6 +19,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class TaskConsumerConfig {
 
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
     private final XML taskConsumerSettings;
 
     @Bean
@@ -26,6 +30,8 @@ public class TaskConsumerConfig {
         Map<String, Object> properties = new HashMap<>();
         properties.put(ConsumerConfig.GROUP_ID_CONFIG,
                 parser.parse("groupId"));
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapServers);
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 parser.parse("keyDeserializerClass"));
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,

--- a/src/main/resources/kafka/requirementProducer.xml
+++ b/src/main/resources/kafka/requirementProducer.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <requirementProducer>
-    <bootstrapServers>kafka-service:9092</bootstrapServers>
     <keySerializerClass>org.apache.kafka.common.serialization.StringSerializer</keySerializerClass>
     <valueSerializerClass>org.springframework.kafka.support.serializer.JsonSerializer</valueSerializerClass>
 </requirementProducer>

--- a/src/main/resources/kafka/taskConsumer.xml
+++ b/src/main/resources/kafka/taskConsumer.xml
@@ -2,7 +2,6 @@
 <taskConsumer>
     <requiredTaskKey>requiredTask</requiredTaskKey>
     <groupId>taskConsumer</groupId>
-    <bootstrapServers>kafka-service:9092</bootstrapServers>
     <keyDeserializerClass>org.apache.kafka.common.serialization.StringDeserializer</keyDeserializerClass>
     <valueDeserializerClass>org.apache.kafka.common.serialization.StringDeserializer</valueDeserializerClass>
 </taskConsumer>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates Kafka configuration in the code. 

### Detailed summary
- `bootstrapServers` property removed from `requirementProducer.xml`
- `bootstrapServers` property added to `taskConsumer.xml`
- `bootstrapServers` property read from application properties in `TaskConsumerConfig.java`
- `keySerializerClass` and `valueSerializerClass` added to `RequirementProducerConfig.java`
- `keyDeserializerClass` and `valueDeserializerClass` added to `TaskConsumerConfig.java`
- `ConsumerConfig.GROUP_ID_CONFIG` property added to `TaskConsumerConfig.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->